### PR TITLE
Fix: case customSizes has only 1 item

### DIFF
--- a/src/utopia.scss
+++ b/src/utopia.scss
@@ -178,7 +178,7 @@
 @function calculateCustomPairs($config, $sizes) {
   $pairs: ();
   $customSizes: map.get($config, "customSizes");
-  @if (meta.type-of($customSizes) != "list") {
+  @if (meta.type-of($customSizes) != "list" and meta.type-of($customSizes) != "string") {
     @return $pairs;
   }
 


### PR DESCRIPTION
When I run generateSpaceScale with ‘customSizes’ only contains 1 item, the output css variables didn’t contain that custom space.

**INPUT**
/* @link https://utopia.fyi/space/calculator?c=320,16,1.2,1440,18,1.25,2,2,375&s=0.75|0.5|0.25,1.25|1.5|1.75|2|3|4|5|7|9,xl-7xl&g=s,l,xl,12 */

:root {
  @include utopia.generateSpaceScale((
    "minWidth": 320,
    "maxWidth": 1440,
    "minSize": 16,
    "maxSize": 18,
    "positiveSteps": (1.25, 1.5, 1.75, 2, 3, 4, 5, 7, 9),
    "negativeSteps": (0.75, 0.5, 0.25),
    **"customSizes": ("xl-7xl"),**
    "prefix": "space-",
    "relativeTo": "viewport-width",
  ));
}

**OUTPUT**
/* @link https://utopia.fyi/space/calculator?c=320,16,1.2,1440,18,1.25,2,2,375&s=0.75|0.5|0.25,1.25|1.5|1.75|2|3|4|5|7|9,xl-7xl&g=s,l,xl,12 */
  --space-3xs: clamp(0.25rem, 0.2321rem + 0.0893vw, 0.3125rem);
  --space-2xs: clamp(0.5rem, 0.4821rem + 0.0893vw, 0.5625rem);
  --space-xs: clamp(0.75rem, 0.7143rem + 0.1786vw, 0.875rem);
  --space-s: clamp(1rem, 0.9643rem + 0.1786vw, 1.125rem);
  --space-m: clamp(1.25rem, 1.1964rem + 0.2679vw, 1.4375rem);
  --space-l: clamp(1.5rem, 1.4464rem + 0.2679vw, 1.6875rem);
  --space-xl: clamp(1.75rem, 1.6786rem + 0.3571vw, 2rem);
  --space-2xl: clamp(2rem, 1.9286rem + 0.3571vw, 2.25rem);
  --space-3xl: clamp(3rem, 2.8929rem + 0.5357vw, 3.375rem);
  --space-4xl: clamp(4rem, 3.8571rem + 0.7143vw, 4.5rem);
  --space-5xl: clamp(5rem, 4.8214rem + 0.8929vw, 5.625rem);
  --space-6xl: clamp(7rem, 6.75rem + 1.25vw, 7.875rem);
  --space-7xl: clamp(9rem, 8.6786rem + 1.6071vw, 10.125rem);
  --space-3xs-2xs: clamp(0.25rem, 0.1607rem + 0.4464vw, 0.5625rem);
  --space-2xs-xs: clamp(0.5rem, 0.3929rem + 0.5357vw, 0.875rem);
  --space-xs-s: clamp(0.75rem, 0.6429rem + 0.5357vw, 1.125rem);
  --space-s-m: clamp(1rem, 0.875rem + 0.625vw, 1.4375rem);
  --space-m-l: clamp(1.25rem, 1.125rem + 0.625vw, 1.6875rem);
  --space-l-xl: clamp(1.5rem, 1.3571rem + 0.7143vw, 2rem);
  --space-xl-2xl: clamp(1.75rem, 1.6071rem + 0.7143vw, 2.25rem);
  --space-2xl-3xl: clamp(2rem, 1.6071rem + 1.9643vw, 3.375rem);
  --space-3xl-4xl: clamp(3rem, 2.5714rem + 2.1429vw, 4.5rem);
  --space-4xl-5xl: clamp(4rem, 3.5357rem + 2.3214vw, 5.625rem);
  --space-5xl-6xl: clamp(5rem, 4.1786rem + 4.1071vw, 7.875rem);
  --space-6xl-7xl: clamp(7rem, 6.1071rem + 4.4643vw, 10.125rem);
  **// --space-xl-7xl is NOT output**
