### PR TITLE
fix: replace deprecated Sass if() with @if directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "utopia-core-scss",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "utopia-core-scss",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "sass": "^1.70.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utopia-core-scss",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Utopia.fyi fluid calculations in SCSS",
   "main": "src/utopia.scss",
   "style": "src/utopia.scss",

--- a/src/helpers.scss
+++ b/src/helpers.scss
@@ -71,7 +71,9 @@
     @warn "List index is #{$index} but list is only #{list.length($list)} item long for `remove-nth`.";
   } @else {
     $result: ();
-    $index: if($index < 0, list.length($list) + $index + 1, $index);
+    @if $index < 0 {
+      $index: list.length($list) + $index + 1;
+    }
 
     @for $i from 1 through list.length($list) {
       @if $i != $index {


### PR DESCRIPTION
Sass’s `if()` function is being deprecated to “make room” for native CSS’s `if()` syntax.

This change replaces the function with Sass’s `@if` directive to ensure compatibility in the future.

(Fortunately, there was only one place where `if()` was being used; everywhere else already uses `@if`!)